### PR TITLE
Feature/issue #49

### DIFF
--- a/app/templates/src/styles/_style.scss
+++ b/app/templates/src/styles/_style.scss
@@ -185,4 +185,6 @@
 
 // @import '../../bower_components/plumpcss-responsive-text-align/trumps.text-align-responsive';
 
+// @import '../../bower_components/inuit-widths/trumps.widths';
+
 // @import '../../bower_components/inuit-widths-responsive/trumps.widths-responsive';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-plump-webapp",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Plump Yeoman generator for HTML/CSS/JS using Inuit 6 alpha",
   "license": "MIT",
   "repository": "plumpdigital/generator-plump-webapp",


### PR DESCRIPTION
The bower component itself is already being pulled by the generator, just incase there's confusion as to why I've only added the import declarative and not the Yeoman `index.js` file.
